### PR TITLE
Do not override header; Remove `Expires` header

### DIFF
--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -525,8 +525,7 @@ class WordPress_Module extends Red_Module {
 				nocache_headers();
 			} else {
 				// Custom cache
-				header( 'Expires: ' . gmdate( 'D, d M Y H:i:s T', time() + $options['redirect_cache'] * 60 * 60 ) );
-				header( 'Cache-Control: max-age=' . $options['redirect_cache'] * 60 * 60 );
+				header( 'Cache-Control: max-age=' . $options['redirect_cache'] * 60 * 60, false );
 			}
 		}
 


### PR DESCRIPTION
## Do not override the header
Allows custom code to set cache control before calling `wp_redirect`. 

Take the following code for example: Which doesn't work.
```
header( 'Cache-Control: max-age=86400, must-revalidate, public' );
wp_safe_redirect( user_trailingslashit( $redirect_to ), 301, 'custom-redirect' );
exit;
```

To make this work header call needs to be placed after the redirect call; note this requires ignoring VIP phpcs rule.
```
wp_safe_redirect( user_trailingslashit( $redirect_to ), 301, 'code' ); // phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit
header( 'Cache-Control: max-age=86400, must-revalidate, public' );
exit;
```
## Remove the `Expires` header.

The `Expires` header is ignored when cache-control is set: See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires
> Note: If there is a [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) header with the max-age or s-maxage directive in the response, the Expires header is ignored.